### PR TITLE
Add Profile model (OneToOne user, bio, avatar) and register in adminfeat(blog): add Profile model with avatar and bio, register in admin

### DIFF
--- a/blog/models.py
+++ b/blog/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.conf import settings
 # Create your models here.
 
 class Category(models.Model):
@@ -39,3 +40,15 @@ class Profile(models.Model):
 
     def __str__(self):
         return f"{self.user.username}'s profile"
+
+class Profile(models.Model):
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='profile'
+    )
+    bio = models.TextField(blank=True)
+    avatar = models.ImageField(upload_to='avatars/', blank=True, null=True)
+
+    def __str__(self):
+        return f"Profile of {self.user}"

--- a/blog/serializers.py
+++ b/blog/serializers.py
@@ -2,7 +2,8 @@
 from rest_framework import routers, serializers, viewsets
 
 # Import the models to serialize
-from .models import Post, Comment, Category
+from .models import Post, Comment, Category, Profile
+
 
 class PostSerializer(serializers.ModelSerializer):
     class Meta:
@@ -21,3 +22,9 @@ class CategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = Category
         fields = '__all__'
+
+class ProfileSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Profile
+        fields = ['id', 'user', 'bio', 'avatar']
+

--- a/blog/urls.py
+++ b/blog/urls.py
@@ -1,11 +1,12 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import PostViewSet, CommentViewSet, CategoryViewSet
+from .views import PostViewSet, CommentViewSet, CategoryViewSet, ProfileViewSet
 
 router = DefaultRouter()
 router.register(r'posts', PostViewSet)
 router.register(r'comments', CommentViewSet)
 router.register(r'categories', CategoryViewSet)
+router.register(r'profiles', ProfileViewSet)
 
 urlpatterns = [
     path('', include(router.urls))

--- a/blog/views.py
+++ b/blog/views.py
@@ -1,28 +1,25 @@
 from django.shortcuts import render
+# blog/views.py
 from rest_framework import viewsets
-from .models import Post, Comment, Category
-from .serializers import PostSerializer, CommentSerializer, CategorySerializer
+from rest_framework import viewsets, permissions
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+
+from .models import Post, Comment, Category, Profile
+from .permissions import IsAuthorOrReadOnly
+from .serializers import PostSerializer, CommentSerializer, CategorySerializer, ProfileSerializer
+
 
 # Create your viewsets here.
 # class PostViewSet (viewsets.ModelViewSet):
 #     queryset = Post.objects.all()
 #     serializer_class = PostSerializer
-
 # class CommentViewSet (viewsets.ModelViewSet):
 #     queryset = Comment.objects.all()
 #     serializer_class = CommentSerializer
-
 # class CategoryViewSet (viewsets.ModelViewSet):
 #     queryset = Category.objects.all()
 #     serializer_class = CategorySerializer
-
-# blog/views.py
-from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from .permissions import IsAuthorOrReadOnly
-from .models import Post, Comment, Category
-from .serializers import PostSerializer, CommentSerializer, CategorySerializer
-from rest_framework.permissions import IsAuthenticated
 
 
 class PostViewSet(viewsets.ModelViewSet):
@@ -40,3 +37,14 @@ class CategoryViewSet(viewsets.ModelViewSet):
     queryset = Category.objects.all()
     serializer_class = CategorySerializer
     permission_classes = [IsAuthenticatedOrReadOnly]  # open CRUD on categories for authenticated users
+
+class IsStaffOrReadOnly(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return request.user and request.user.is_staff
+
+class ProfileViewSet(viewsets.ModelViewSet):
+    queryset = Profile.objects.all()
+    serializer_class = ProfileSerializer
+    permission_classes = [IsStaffOrReadOnly]

--- a/blogsite/settings.py
+++ b/blogsite/settings.py
@@ -137,3 +137,11 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# settings.py
+import os
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+MEDIA_URL = '/media/'
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+

--- a/blogsite/urls.py
+++ b/blogsite/urls.py
@@ -18,10 +18,12 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from rest_framework.authtoken.views import obtain_auth_token
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include ('blog.urls')),
+    path('api-token-auth/', obtain_auth_token),
 ]
 
 if settings.DEBUG:

--- a/blogsite/urls.py
+++ b/blogsite/urls.py
@@ -16,8 +16,14 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path, include
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include ('blog.urls')),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+


### PR DESCRIPTION
### What
This PR adds a `Profile` model to the `blog` app with:
- `user` (OneToOneField to AUTH_USER_MODEL)
- `bio` (TextField)
- `avatar` (ImageField, upload_to='avatars/')

It also:
- registers Profile in the Django admin (blog/admin.py)
- includes migrations

### Why
Needed to store per-user profile details (bio + avatar) for blog users.

### Notes
- Pillow is required for ImageField (`pip install pillow`).
- Media settings and url patterns are set for development in settings.py and urls.py (ensure `MEDIA_ROOT` and `MEDIA_URL` are configured).
